### PR TITLE
Update wan-failover-beta.sh

### DIFF
--- a/wan-failover-beta.sh
+++ b/wan-failover-beta.sh
@@ -2840,11 +2840,11 @@ else
         if [[ "${PINGPATH}" == "0" ]] &>/dev/null;then
           STATUS="DISCONNECTED"
           logger -p 6 -t "${ALIAS}" "Debug - ${WANPREFIX} Status: ${STATUS}"
-          if [[ "${i}" -le "${RECURSIVEPINGCHECK}" ]] &>/dev/null;then
+          if [[ "${i}" -lt "${RECURSIVEPINGCHECK}" ]] &>/dev/null;then
             i="$((${i}+1))"
             setwanstatus && continue
           else
-            setwanstatus && break 1
+            setwanstatus &
           fi
           restartwan${WANSUFFIX} &
           restartwanpid="$!"


### PR DESCRIPTION
There seems to be a bug where you cannot drop into the actual restarting of WANs because the while loop and if statements conflict on the recursivepingcheck.

Additionally, the break also stops the code from continuing to run I believe.


Not too sure if you want this as a PR as an issue.

we have tested this on the beta as it was on @nathan57971 Router and we can successfully restart the wan.

We might have a slightly unique setup which allowed us to spot the issue.

We disabled ppp echos on the asus during some issue with the ISP (unrelated) however we then noticed that when the wan went down it would not recover without rebooting the Asus.


