### PR TITLE
feat: Add ALLOW_UPDATES config option to enable/disable remote updating of script

### DIFF
--- a/wan-failover-beta.sh
+++ b/wan-failover-beta.sh
@@ -1123,6 +1123,14 @@ logger -p 6 -t "${ALIAS}" "Debug - Function: update"
 [[ -z "${updateneeded+x}" ]] &>/dev/null && updateneeded="0"
 [[ -z "${passiveupdate+x}" ]] &>/dev/null && passiveupdate="0"
 
+# Check if remote updates are allowed
+if [[ "${ALLOW_UPDATES}" != "1" ]] &>/dev/null;then
+  echo -e "${RED}***Updates are disabled*** set ALLOW_UPDATES=1 to enable updates${NOCOLOR}"
+  updateneeded="0"
+  passiveupdate="0"
+  return 0
+fi
+
 # Determine Production or Beta Update Channel
 if [[ "${DEVMODE}" == "0" ]] &>/dev/null;then
   DOWNLOADPATH="${REPO}wan-failover.sh"
@@ -1585,6 +1593,10 @@ if [[ "${configdefaultssync}" == "0" ]] &>/dev/null;then
   if [[ -z "$(sed -n '/\bFAILBACKDELAYTIMER=\b/p' "${CONFIGFILE}")" ]] &>/dev/null;then
     logger -p 6 -t "${ALIAS}" "Debug - Creating FAILBACKDELAYTIMER Default: 0"
     echo -e "FAILBACKDELAYTIMER=0" >> ${CONFIGFILE}
+  fi
+  if [[ -z "$(sed -n '/\bALLOW_UPDATES=\b/p' "${CONFIGFILE}")" ]] &>/dev/null;then
+    logger -p 6 -t "${ALIAS}" "Debug - Setting ALLOW_UPDATES Default: Enabled"
+    echo -e "ALLOW_UPDATES=1" >> ${CONFIGFILE}
   fi
 
 # Cleanup Config file of deprecated options

--- a/wan-failover.sh
+++ b/wan-failover.sh
@@ -1123,6 +1123,14 @@ logger -p 6 -t "${ALIAS}" "Debug - Function: update"
 [[ -z "${updateneeded+x}" ]] &>/dev/null && updateneeded="0"
 [[ -z "${passiveupdate+x}" ]] &>/dev/null && passiveupdate="0"
 
+# Check if remote updates are allowed
+if [[ "${ALLOW_UPDATES}" != "1" ]] &>/dev/null;then
+  echo -e "${RED}***Updates are disabled*** set ALLOW_UPDATES=1 to enable updates${NOCOLOR}"
+  updateneeded="0"
+  passiveupdate="0"
+  return 0
+fi
+
 # Determine Production or Beta Update Channel
 if [[ "${DEVMODE}" == "0" ]] &>/dev/null;then
   DOWNLOADPATH="${REPO}wan-failover.sh"
@@ -1585,6 +1593,10 @@ if [[ "${configdefaultssync}" == "0" ]] &>/dev/null;then
   if [[ -z "$(sed -n '/\bFAILBACKDELAYTIMER=\b/p' "${CONFIGFILE}")" ]] &>/dev/null;then
     logger -p 6 -t "${ALIAS}" "Debug - Creating FAILBACKDELAYTIMER Default: 0"
     echo -e "FAILBACKDELAYTIMER=0" >> ${CONFIGFILE}
+  fi
+  if [[ -z "$(sed -n '/\bALLOW_UPDATES=\b/p' "${CONFIGFILE}")" ]] &>/dev/null;then
+    logger -p 6 -t "${ALIAS}" "Debug - Setting ALLOW_UPDATES Default: Enabled"
+    echo -e "ALLOW_UPDATES=1" >> ${CONFIGFILE}
   fi
 
 # Cleanup Config file of deprecated options


### PR DESCRIPTION
Adds a config option: `ALLOW_UPDATES`. Defaults to `ALLOW_UPDATES=1` (allowed).

If not set to `ALLOW_UPDATES=1` (0, unset, or any other value), the `update()` function will short-circuit with a warning message. This will keep a working script at an admin-reviewed version installed on a device and preclude any unexpected changes from being introduced.

Admins can edit the config to `ALLOW_UPDATES`, then run the update command to take remote updates on their schedule.

Sets `updateneeded` and `passiveupdate` before short-circuiting so that the `status` display still works.

# Question

Should I update both the `-beta` and main script? Or just the `-beta` script?

# Details

## Installation

![photo_2025-03-22_12-53-01](https://github.com/user-attachments/assets/5c05ce56-61c2-431d-abbe-b9c4ca0439a6)

Produces this initial config (note `ALLOW_UPDATES=1` at the bottom):

![photo_2025-03-22_12-53-03](https://github.com/user-attachments/assets/fa4fe4ce-ec07-4abd-ba4e-b1a3fd6fa9eb)

## Update Attempt Allowed

I have local edits - these changes! - so my checksum doesn't match. However, the update is offered:

![photo_2025-03-22_12-53-05](https://github.com/user-attachments/assets/bc829dff-2260-4fce-9659-c638250fe2fe)

## Update Attempt Denied

With `ALLOW_UPDATES=0` set in config,

![photo_2025-03-22_12-53-06](https://github.com/user-attachments/assets/2fb74853-1f57-45db-8700-3e92c4e3a6ee)
