### PR TITLE
feat: Add explicit, custom asusmerlin-style hook for WAN failover

### DIFF
--- a/wan-failover-beta.sh
+++ b/wan-failover-beta.sh
@@ -5546,6 +5546,10 @@ elif [[ "${ACTIVEWAN}" == "${WAN1}" ]] &>/dev/null;then
   SWITCHWANMODE="Failover"
 fi
 
+# Emit failover/back event hook
+EVENT_TOKEN=$(echo ${SWITCHWANMODE} | tr '[A-Z]' '[a-z]' | sed 's/fail/failing-/')
+[[ -f /jffs/scripts/wan-failover-event ]] && /jffs/scripts/wan-failover-event "${ACTIVEWAN}" "${EVENT_TOKEN}"
+
 # Execute Failback Delay Timer
 if [[ "${SWITCHWANMODE}" == "Failback" ]] &>/dev/null && [[ "${FAILBACKDELAYTIMER}" -gt "0" ]] &>/dev/null;then
   sleep ${FAILBACKDELAYTIMER}
@@ -5694,6 +5698,8 @@ until { [[ "$(nvram get ${INACTIVEWAN}_primary & nvramcheck)" == "0" ]] &>/dev/n
 done
 if [[ "$(nvram get ${ACTIVEWAN}_primary & nvramcheck)" == "1" ]] &>/dev/null && [[ "$(nvram get ${INACTIVEWAN}_primary & nvramcheck)" == "0" ]] &>/dev/null;then
   [[ "${SWITCHPRIMARY}" == "1" ]] &>/dev/null && logger -p 1 -st "${ALIAS}" "${SWITCHWANMODE} - Switched ${ACTIVEWAN} to Primary WAN"
+  EVENT_TOKEN=$(echo ${SWITCHWANMODE} | tr '[A-Z]' '[a-z]' | sed 's/fail/failed-/')
+  [[ -f /jffs/scripts/wan-failover-event ]] && /jffs/scripts/wan-failover-event "${ACTIVEWAN}" "${EVENT_TOKEN}"
 else
   debuglog || return 1
 fi

--- a/wan-failover-beta.sh
+++ b/wan-failover-beta.sh
@@ -5548,7 +5548,7 @@ fi
 
 # Emit failover/back event hook
 EVENT_TOKEN=$(echo ${SWITCHWANMODE} | tr '[A-Z]' '[a-z]' | sed 's/fail/failing-/')
-[[ -f /jffs/scripts/wan-failover-event ]] && /jffs/scripts/wan-failover-event "${ACTIVEWAN}" "${EVENT_TOKEN}"
+[[ -f /jffs/scripts/wan-failover-event ]] && /jffs/scripts/wan-failover-event "${ACTIVEWAN#wan}" "${EVENT_TOKEN}"
 
 # Execute Failback Delay Timer
 if [[ "${SWITCHWANMODE}" == "Failback" ]] &>/dev/null && [[ "${FAILBACKDELAYTIMER}" -gt "0" ]] &>/dev/null;then
@@ -5699,7 +5699,7 @@ done
 if [[ "$(nvram get ${ACTIVEWAN}_primary & nvramcheck)" == "1" ]] &>/dev/null && [[ "$(nvram get ${INACTIVEWAN}_primary & nvramcheck)" == "0" ]] &>/dev/null;then
   [[ "${SWITCHPRIMARY}" == "1" ]] &>/dev/null && logger -p 1 -st "${ALIAS}" "${SWITCHWANMODE} - Switched ${ACTIVEWAN} to Primary WAN"
   EVENT_TOKEN=$(echo ${SWITCHWANMODE} | tr '[A-Z]' '[a-z]' | sed 's/fail/failed-/')
-  [[ -f /jffs/scripts/wan-failover-event ]] && /jffs/scripts/wan-failover-event "${ACTIVEWAN}" "${EVENT_TOKEN}"
+  [[ -f /jffs/scripts/wan-failover-event ]] && /jffs/scripts/wan-failover-event "${ACTIVEWAN#wan}" "${EVENT_TOKEN}"
 else
   debuglog || return 1
 fi


### PR DESCRIPTION
# Description

Adds support for an asusmerlin-style hook called when a WAN failover event happens to allow hooking into when the active WAN switches. This is more-precise than the existing `wan-event` whose starting, stopped, stopping, etc, doesn't account for the "hot standby" / "cold standby" of inactive - but connected - WANs.

# Interface

Calls `/jffs/scripts/wan-failover-event <wan> <failing-over|failed-over>`, e.g.

1. `/jffs/scripts/wan-failover-event 1 failing-over` (beginning to fail over to WAN1, from WAN0)
2.  `/jffs/scripts/wan-failover-event 1 failed-over` (completed activating WAN1 after failover from WAN0)
3. `/jffs/scripts/wan-failover-event 0 failing-over` (beginning to fail back to WAN0 from WAN1)
4. `jffs/scripts/wan-failover-event 0 failed-over` (completed reactivating WAN0 after it came back online)

# Uses

I use this to drive the external LEDs on my router to visually indicate WAN status. It could also be used to hook up notifications other than the e-mail notification capability, such as into a homeassistant setup, etc.

I'm not sure if this is the *best* way to do this, but it's been working on my router for a couple months.